### PR TITLE
Fix Unicode error in hints section

### DIFF
--- a/submit_and_compare/submit_and_compare.py
+++ b/submit_and_compare/submit_and_compare.py
@@ -199,14 +199,15 @@ class SubmitAndCompareXBlock(XBlock):
         decorated_hints = list()
 
         if len(raw_hints) == 1:
-            hint = 'Hint: ' + etree.tostring(raw_hints[0], encoding='unicode')
+            hint = u'Hint: ' + etree.tostring(raw_hints[0], encoding='unicode')
             decorated_hints.append(hint)
         else:
             for i in range(len(raw_hints)):
-                hint = 'Hint ({number} of {total}): {hint}'.format(
+                hint = u'Hint ({number} of {total}): {hint}'.format(
                     number=i + 1,
                     total=len(raw_hints),
-                    hint=etree.tostring(raw_hints[i], encoding='unicode'))
+                    hint=etree.tostring(raw_hints[i], encoding='unicode'),
+                )
                 decorated_hints.append(hint)
 
         hints = decorated_hints


### PR DESCRIPTION
This commit fixes the error that was brought to our attention by
our automated code diagnostics tool. The problem was successfully
replicated by using the unicode character: 'μ' in the hints section of
the xblock and attempting to save changes as an instructor. The problem was
that we were previously calling python's 'format' method on a
non-unicode string, but passing in one or more unicode arguments to the
function. In order to fix the bug, I ensured that format was being called on
a unicode string. For more details on the nature of the issue see:
http://www.saltycrane.com/blog/2014/07/old-string-formatting-and-new-format-method-handle-unicode-differently/
