### PR TITLE
Add tox dependency on opaque-keys to match platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     install_requires=[
         'XBlock',
         'django',
-        'edx-opaque-keys',
         'mock',
         'django_nose',
         'coverage',

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,23 @@
+# Note: The testing environemnt depends on version 0.1.2 of opaque_keys, which
+#       is not available on PyPi. The reason this dependency is included here is to
+#       match the version used Stanford-Online's fork of edx-platform.
 [tox]
 downloadcache = {toxworkdir}/_download/
 envlist = py27-dj{14,18},coverage,pep8,pylint,pyflakes
 
 [testenv]
+deps=
+
 commands = {envpython} manage.py test
 
 [testenv:py27-dj14]
 deps =
+    git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
     django == 1.4.22
 
 [testenv:py27-dj18]
 deps =
+    git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
     django >= 1.8, < 1.9
 
 [testenv:pep8]
@@ -30,6 +37,7 @@ commands = {envbindir}/pyflakes submit_and_compare/
 # https://docs.python.org/devguide/coverage.html#common-gotchas
 [testenv:coverage]
 deps =
+    git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
     coverage
 setenv =
     NOSE_COVER_TESTS=1
@@ -39,6 +47,7 @@ commands =
 
 [testenv:coveralls]
 deps =
+    git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
     coverage
     coveralls
 setenv =


### PR DESCRIPTION
This commit adds a dependency to the tox setup on
version 0.1.2 of opaque_keys, as used by
Stanford-Online's fork of edx-platform. This
was added as a tox dependency instead of being
included in the `install_requires` array of the
xblock's setup.py because the version of opaque_keys
is not available on PyPi.
