### PR TITLE
Fix progress page max_score scoring issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info/
 *.pyc
 *.sw[op]
+coverage.xml

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class Tox(TestCommand):
 
 setup(
     name='xblock-submit-and-compare',
-    version='0.5',
+    version='0.5.1',
     description='Submit and Compare XBlock for self assessment',
     packages=[
         'submit_and_compare',

--- a/submit_and_compare/submit_and_compare.py
+++ b/submit_and_compare/submit_and_compare.py
@@ -272,6 +272,16 @@ class SubmitAndCompareXBlock(XBlock):
         frag.initialize_js('SubmitAndCompareXBlockInitEdit')
         return frag
 
+    def max_score(self):
+        """
+        Returns the configured number of possible points for this component.
+        Arguments:
+            None
+        Returns:
+            float: The number of possible points for this component
+        """
+        return self.weight
+
     @XBlock.json_handler
     def student_submit(self, submissions, suffix=''):
         # pylint: disable=unused-argument

--- a/submit_and_compare/tests.py
+++ b/submit_and_compare/tests.py
@@ -191,3 +191,11 @@ class SubmitAndCompareXblockTestCase(unittest.TestCase):
         self.xblock.max_attempts = 5
         self.xblock.count_attempts = 6
         self.assertEquals('nodisplay', self.xblock._get_submit_class())
+
+    def test_max_score(self):
+        """
+        Tests max_score function
+        Should return the weight
+        """
+        self.xblock.weight = 4
+        self.assertEquals(self.xblock.weight, self.xblock.max_score())


### PR DESCRIPTION
max_score function needs to be included in
xblocks so the LMS progress page correctly
reports the progress for a subsection. Not
fixing this is confusing to the student and
could result in grading errors.

@kluo @stvstnfrd PR for fixing progress issue by adding max_score function to xblock.

https://trello.com/c/PqrXDAYi/669-graded-xblocks-not-correctly-reflected-in-grading