### PR TITLE
Stop count_attemps for being limited to one

### DIFF
--- a/submit_and_compare/submit_and_compare.py
+++ b/submit_and_compare/submit_and_compare.py
@@ -290,11 +290,7 @@ class SubmitAndCompareXBlock(XBlock):
             self.student_answer = submissions['answer']
 
             if submissions['action'] == 'submit':
-                # the user can make an unlimited number of attempts
-                if self.max_attempts == 0:
-                    self.count_attempts = 1
-                else:
-                    self.count_attempts += 1
+                self.count_attempts += 1
 
             if self.student_answer:
                 self.score = 1.0


### PR DESCRIPTION
@stvstnfrd @caesar2164 PR for stop count attempts from being limited to one when max_attempts was set to zero.

If max_attempts was zero, implying unlimited attempts,
then count_attempts was being limited to one.